### PR TITLE
Minor bug fixes

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -9,6 +9,7 @@ import {
   InteractionTypes,
   verifySignature
 } from "discordeno/mod.ts";
+import { camelize } from 'https://deno.land/x/camelize@2.0.0/mod.ts';
 
 import { commands } from "template/commands/mod.ts";
 import { translate } from "template/languages/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -91,7 +91,8 @@ async function main(request: Request) {
         type: InteractionResponseTypes.ChannelMessageWithSource,
         data: {
           content: translate(
-            payload.guildId!,
+            // discordeno marks guildId as bigint, so need to convert it to string, else translate function throws error
+            payload.guildId! as unknown as string,
             "MISSING_PERM_LEVEL",
           ),
         },

--- a/mod.ts
+++ b/mod.ts
@@ -59,7 +59,7 @@ async function main(request: Request) {
     });
   }
 
-  const payload = camelize<Interaction>(JSON.parse(body));
+  const payload = camelize<Interaction>(JSON.parse(body)) as Interaction;
   if (payload.type === InteractionTypes.Ping) {
     return json({
       type: InteractionResponseTypes.Pong,


### PR DESCRIPTION
Fixes
- Camelize function was used [here](https://github.com/discordeno/serverless-deno-deploy-template/blob/main/mod.ts#L61) but it was never imported - [**0c9ca70**](https://github.com/discordeno/serverless-deno-deploy-template/commit/0c9ca703c11c7c352c29870019e5cc2c0fbf202d)
- Camelize returns `Camelize<Interaction>` but payload is expected to be `Interaction` so type coerce it to just `Interaction`  - [**4cb2330**](https://github.com/discordeno/serverless-deno-deploy-template/commit/4cb23301024fc86917f693f1a749cb27863da959)
- Discordeno types guildId as `bigint` but translate expects it as `string`, so type coerce it - [**b459b9a**](https://github.com/discordeno/serverless-deno-deploy-template/commit/b459b9a14a3d50635d2023b83957d94c41618683)

Unfixed 
- `sendWebhook` function was imported [here](https://github.com/discordeno/serverless-deno-deploy-template/blob/main/src/utils/logWebhook.ts#L3) from deps.ts but file doesnt exist. Not sure where the function actually exists so couldn't solve that